### PR TITLE
Revert "Feat: 채널 상세 조회 권한 제어 및 AccountCheck 데이터 변경"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,3 @@ out/
 .vscode/
 bipa4.pem
 .log
-log/bipa4RestAPI.log

--- a/src/main/java/com/bipa4/back_bipatv/controller/ReadController.java
+++ b/src/main/java/com/bipa4/back_bipatv/controller/ReadController.java
@@ -160,9 +160,8 @@ public class ReadController {
   @ApiOperation(value = "채널 상세 조회", notes = "채널 상세 조회")
   @GetMapping("/channel/{channelId}")
   public ResponseEntity<SelectChannelDTO> getMyChannelInfo(
-      @CookieValue(value = "accessToken", required = false) String accessToken,
       @PathVariable("channelId") UUID channelId) {
-    SelectChannelDTO responseDto = channelService.findChannel(channelId, accessToken);
+    SelectChannelDTO responseDto = channelService.findChannel(channelId);
     return new ResponseEntity<>(responseDto, HttpStatus.OK);
   }
 

--- a/src/main/java/com/bipa4/back_bipatv/dto/user/GetAccountCheckDTO.java
+++ b/src/main/java/com/bipa4/back_bipatv/dto/user/GetAccountCheckDTO.java
@@ -8,6 +8,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class GetAccountCheckDTO {
 
+  private UUID accountId;
+  private String loginId;
+  private String userName;
+  private String userProfileUrl;
+  private String eMail;
   private UUID channelId;
   private String channelName;
   private String channelProfileUrl;

--- a/src/main/java/com/bipa4/back_bipatv/repository/AccountRepositoryImpl.java
+++ b/src/main/java/com/bipa4/back_bipatv/repository/AccountRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.bipa4.back_bipatv.repository;
 
 import com.bipa4.back_bipatv.dto.user.GetAccountCheckDTO;
+import com.bipa4.back_bipatv.entity.QAccounts;
 import com.bipa4.back_bipatv.entity.QChannels;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -16,19 +17,25 @@ public class AccountRepositoryImpl implements AccountRepositoryCustom {
 
   @Override
   public GetAccountCheckDTO getAccountCheckDto(UUID accountId) {
-
+    QAccounts qAccounts = QAccounts.accounts;
     QChannels qChannels = QChannels.channels;
 
     return jpaQueryFactory.select(
             Projections.bean(
                 GetAccountCheckDTO.class,
+                qAccounts.accountId,
+                qAccounts.loginId,
+                qAccounts.name.as("userName"),
+                qAccounts.profileUrl.as("userProfileUrl"),
+                qAccounts.eMail,
                 qChannels.channelId,
                 qChannels.channelName,
                 qChannels.profileUrl.as("channelProfileUrl")
 
             )
         ).from(qChannels)
-        .where(qChannels.accounts.accountId.eq(accountId)
+        .leftJoin(qChannels.accounts, qAccounts)
+        .where(qAccounts.accountId.eq(accountId)
         ).fetchOne();
   }
 }

--- a/src/main/java/com/bipa4/back_bipatv/repository/ChannelRepository.java
+++ b/src/main/java/com/bipa4/back_bipatv/repository/ChannelRepository.java
@@ -13,7 +13,7 @@ public interface ChannelRepository extends JpaRepository<Channels, UUID>, Channe
       + "join accounts b "
       + "on a.account_id = b.account_id "
       + "where b.account_id = :accountId", nativeQuery = true)
-  Optional<Channels> findByChannelToAccountId(UUID accountId);
+  Optional<Channels> findByChannelToAccountId(Long accountId);
 
 
   Channels findByChannelId(UUID channelId);

--- a/src/main/java/com/bipa4/back_bipatv/service/ChannelService.java
+++ b/src/main/java/com/bipa4/back_bipatv/service/ChannelService.java
@@ -58,26 +58,8 @@ public class ChannelService {
     return true;
   }
 
-  public SelectChannelDTO findChannel(UUID channelId, String accessToken) {
-    Accounts loginUser = securityService.getSubjectAccount(accessToken);
-    Channels loginUserChannel = null;
-    SelectChannelDTO selectChannel = channelRepository.selectChannel(channelId);
-
-    if (loginUser != null) {
-      loginUserChannel = channelRepository.findByChannelToAccountId(
-          loginUser.getAccountId()).orElse(null);
-    }
-
-    if (loginUser == null && selectChannel.isPrivateType()) {// 비회원이 private으로 설정된 채널 들어가려할때
-      throw new AuthorizationException();
-    }
-
-    if (loginUserChannel != null && !loginUserChannel.getChannelId()
-        .equals(selectChannel.getChannelId())
-        && selectChannel.isPrivateType()) {//채널 주인이 아닌 경우
-      throw new AuthorizationException();
-    }
-    return selectChannel;
+  public SelectChannelDTO findChannel(UUID channelId) {
+    return channelRepository.selectChannel(channelId);
   }
 
   public Channels findbyChannelId(UUID channelId) {


### PR DESCRIPTION
Reverts bipa-4/api#124

액세스토큰이 http only 쿠키로 전달되기 때문에,
프론트엔드 서버사이드 렌더링 환경에서 유저 검증정보를 백엔드로 보낼수가 없습니다.
따라서 권한 검증을 위해서는 클라이언트 사이드에서 요청을 보내야 하는데,
이렇게 될 경우 페이지 별 meta tag설정이 어렵고 검색엔진 노출과 소셜공유에 치명적인 문제가 발생하게 됩니다.